### PR TITLE
Consider exception as results

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject clanhr/result "0.15.0"
+(defproject clanhr/result "0.16.0"
   :description "Generic result representation"
   :url "https://github.com/clanhr/result"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/core.async "0.1.346.0-17112a-alpha"]]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [org.clojure/core.async "0.2.395"]]
   :aliases {"autotest" ["with-profile" "+test" "test-refresh"]}
   :profiles {:test {:env {:secret "test_secret"}
                     :plugins [[com.jakemccrary/lein-test-refresh "0.17.0"]]}})

--- a/src/result/core.clj
+++ b/src/result/core.clj
@@ -65,6 +65,11 @@
   (-> (failure "Exception")
       (assoc :exception ex)))
 
+(defn exception?
+  "True if the result has an exception"
+  [result]
+  (:exception result))
+
 (defn has-value?
   "Returns success or failure based on the result having object or not"
   [result]
@@ -151,11 +156,14 @@
   It not, the failed result is returned."
   [bindings & body]
    (let [form (bindings 0) tst (bindings 1)]
-    `(let [temp# ~tst]
-       (if (succeeded? temp#)
-         (let [~form temp#]
-           ~@body)
-         temp#))))
+     `(try
+        (let [temp# ~tst]
+           (if (succeeded? temp#)
+             (let [~form temp#]
+               ~@body)
+             temp#))
+        (catch Exception e#
+          (exception e#)))))
 
 (defmacro enforce-let
   "Gathers all results, checking each one in order if failed. If one fails,

--- a/test/result/core_test.clj
+++ b/test/result/core_test.clj
@@ -158,6 +158,13 @@
         (result/succeeded? r3)
         r3))))
 
+  (testing "inner exception"
+    (let [result (result/enforce-let [r1 (result/success)
+                                      r2 (throw (ex-info "Test" {}))
+                                      r3 (result/success)])]
+      (is (result/failed? result))
+      (is (result/exception? result))))
+
   (testing "No body"
     (is (result/failed?
       (result/enforce-let [r1 (result/failure "First failure")


### PR DESCRIPTION
If during an enforce-let or on-success an exception occurs, it isn't
caught and it's harder to get info about it on our current stack. This
patch catches the exception and returns it as a proper result.